### PR TITLE
Remove bad validation from un-regexed partial parts

### DIFF
--- a/cicd/.gitignore
+++ b/cicd/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/pkg/route/part.go
+++ b/pkg/route/part.go
@@ -12,16 +12,11 @@ const (
 	// part matching
 	regexp_wildcard = string(`/\[(.*?)\](.*)`)
 	regexp_regex    = string(`[/\]]{(.*)}`)
-	// handy constants to have around
-	regexp_anyWord = string(`\w+`)
 )
 
 // Regex used for parsing tokens
 var regexp_wildcard_compiled *regexp.Regexp = regexp.MustCompile(regexp_wildcard)
 var regexp_regex_compiled *regexp.Regexp = regexp.MustCompile(regexp_regex)
-
-// Compiled regex for any word
-var regexp_anyWord_compiled *regexp.Regexp = regexp.MustCompile(regexp_anyWord)
 
 // Parts are the main body of a Route, and are an interface defining
 // a Match function against tokens in a request URL.

--- a/pkg/route/partial.go
+++ b/pkg/route/partial.go
@@ -26,7 +26,7 @@ func parse_partialEndPart(token string) (*partialEndPart, error) {
 	subToken := token[:len(token)-1]
 	// if subToken is empty, use an unqualified anyWord
 	if subToken == "/" {
-		result.subPart = &regexPart{"", regexp_anyWord_compiled}
+		result.subPart = &wildcardPart{""}
 		return result, nil
 	}
 	// otherwise, parse out subToken

--- a/pkg/router/default.go
+++ b/pkg/router/default.go
@@ -40,23 +40,11 @@ func (rt *defaultRouter) Attach(mws ...middleware.Middleware) {
 
 // Add a route to the router.
 //
+// AddRoute is deprecated; use HandleRoute instead.
+//
 // See interface Router.
 func (rt *defaultRouter) AddRoute(r route.Route, h http.Handler) {
-	id := rt.rtree.Add(r)
-	if rt.routes[r.Method()] == nil {
-		rt.routes[r.Method()] = make(map[int]route.Route)
-	}
-	rt.routes[r.Method()][id] = r
-	if rt.handlers[r.Method()] == nil {
-		rt.handlers[r.Method()] = make(map[int]http.Handler)
-	}
-	if h != nil {
-		rt.handlers[r.Method()][id] = h
-
-	} else {
-		rt.handlers[r.Method()][id] = nil
-	}
-
+	register(rt, r, h)
 }
 
 func register(rt *defaultRouter, r route.Route, h http.Handler) {
@@ -68,7 +56,11 @@ func register(rt *defaultRouter, r route.Route, h http.Handler) {
 	if rt.handlers[r.Method()] == nil {
 		rt.handlers[r.Method()] = make(map[int]http.Handler)
 	}
-	rt.handlers[r.Method()][id] = h
+	if h != nil {
+		rt.handlers[r.Method()][id] = h
+	} else {
+		rt.handlers[r.Method()][id] = nil
+	}
 }
 
 // Add a route to the router.
@@ -110,7 +102,11 @@ func (rt *defaultRouter) HandleRoute(r route.Route, h http.Handler) {
 //
 // See interface Router.
 func (rt *defaultRouter) HandleRouteFunc(r route.Route, h http.HandlerFunc) {
-	register(rt, r, h)
+	if h != nil {
+		register(rt, r, h)
+	} else {
+		register(rt, r, nil)
+	}
 }
 
 // Mount mounts a handler at path.

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -225,10 +225,10 @@ func TestEdgeCaseRoutes(t *testing.T) {
 		WithRoute(route.Declare(http.MethodGet, "/odd///path"), okHandler("odd")),
 		HandleRoute(route.Declare(http.MethodGet, "/reject", route.WithMiddleware(reject)), okHandler("never")),
 	)
-	r.HandleFunc(http.MethodGet, "/not/implemented", nil)
-	r.Handle(http.MethodGet, "/not/implemented", nil)
-	r.HandleRoute(route.Declare(http.MethodGet, "/"), nil)
-	r.HandleRouteFunc(route.Declare(http.MethodGet, "/"), nil)
+	r.HandleFunc(http.MethodGet, "/not/implemented/handler", nil)
+	r.Handle(http.MethodGet, "/not/implemented/func", nil)
+	r.HandleRoute(route.Declare(http.MethodGet, "/not/implemented/routehandler"), nil)
+	r.HandleRouteFunc(route.Declare(http.MethodGet, "/not/implemented/routefunc"), nil)
 	s := httptest.NewServer(r)
 	runEvalRequest(t, s, "/odd/path", reqGen(http.MethodGet), map[string]any{
 		"code": http.StatusOK,
@@ -241,7 +241,16 @@ func TestEdgeCaseRoutes(t *testing.T) {
 	runEvalRequest(t, s, "/reject", reqGen(http.MethodGet), map[string]any{
 		"code": http.StatusForbidden,
 	})
-	runEvalRequest(t, s, "/not/implemented", reqGen(http.MethodGet), map[string]any{
+	runEvalRequest(t, s, "/not/implemented/handler", reqGen(http.MethodGet), map[string]any{
+		"code": http.StatusNotImplemented,
+	})
+	runEvalRequest(t, s, "/not/implemented/func", reqGen(http.MethodGet), map[string]any{
+		"code": http.StatusNotImplemented,
+	})
+	runEvalRequest(t, s, "/not/implemented/routehandler", reqGen(http.MethodGet), map[string]any{
+		"code": http.StatusNotImplemented,
+	})
+	runEvalRequest(t, s, "/not/implemented/routefunc", reqGen(http.MethodGet), map[string]any{
 		"code": http.StatusNotImplemented,
 	})
 

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -419,6 +419,7 @@ func TestComposition(t *testing.T) {
 	api1 := Default()
 	api1.HandleFunc(http.MethodGet, "/hello", h1)
 	api1.HandleFunc(http.MethodPost, "/hello", h1)
+	api1.HandleFunc(http.MethodGet, "/hello/[name]", h1)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/hello", nil)
@@ -429,6 +430,20 @@ func TestComposition(t *testing.T) {
 
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/hello", nil)
+	api1.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Error(200, w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/hello/jakenichols2719", nil)
+	api1.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Error(200, w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/hello/jakenichols2719.github.com", nil)
 	api1.ServeHTTP(w, req)
 	if w.Code != 200 {
 		t.Error(200, w.Code)
@@ -465,6 +480,13 @@ func TestComposition(t *testing.T) {
 
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/hello", nil)
+	api2.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Error(200, w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/hello/jakenichols2719.github.com", nil)
 	api2.ServeHTTP(w, req)
 	if w.Code != 200 {
 		t.Error(200, w.Code)


### PR DESCRIPTION
Previously, unqualified partial end parts to routes `/+` would match only alphanumeric characters due to regex validation that was being implicitly performed on segments being evaluated for partials. This didn't affect anything that either explicitly set validation, or had a wildcard attached, which was most use cases; however, `Router.Mount` defaults to using unqualified partials, so it was affecting that feature particularly.

My solution is to just stop validating inputs for those segments. Implicit validation is not currently a feature of Matcha, and if it does become one, it won't happen there.